### PR TITLE
[progress.component] remove ngOnDestroy

### DIFF
--- a/src/components/progress/progress.component.ts
+++ b/src/components/progress/progress.component.ts
@@ -82,10 +82,4 @@ export class ProgressComponent implements OnChanges, OnDestroy {
       }
     }
   }
-
-  ngOnDestroy() {
-    this.progress.state.unsubscribe();
-    this.progress.trickling.unsubscribe();
-  }
-
 }


### PR DESCRIPTION
No need to unsubscribe. It also will causing error when we move from one page to another page if still in progress.